### PR TITLE
Fix quality checks: linting, unused vars, and strict typing

### DIFF
--- a/src/apps/scheduler/startup-recovery.ts
+++ b/src/apps/scheduler/startup-recovery.ts
@@ -1,5 +1,4 @@
 import Logger from '@/core/logger';
-import { DOMAINS } from '@/core/logger/constants';
 import { CRON_RUN_SERVICE } from '@/domains/cron/services';
 import { STARTUP_DEFERRED_FAILURE_CODE, STARTUP_DEFERRED_FAILURE_MESSAGE } from './config';
 

--- a/src/core/logger/types.ts
+++ b/src/core/logger/types.ts
@@ -16,7 +16,6 @@ export interface LogTags {
   domain: Domain;
   operation: string;
   component?: string;
-  [key: string]: string | undefined;
 }
 
 /**

--- a/src/domains/auth/api/index.ts
+++ b/src/domains/auth/api/index.ts
@@ -20,7 +20,7 @@ const authenticateUser = async (req: AuthenticateMemberRequest, res: Response) =
         domain: DOMAINS.AUTH,
         component: 'api',
         operation: 'authenticate',
-        errors: errors as any,
+        errors: errors as unknown,
       });
 
       return res.status(ErrorMapper.VALIDATION_ERROR.status).send({

--- a/src/domains/cron/queries/index.ts
+++ b/src/domains/cron/queries/index.ts
@@ -276,13 +276,11 @@ export const QUERIES_CRON_JOB_RUNS = {
     return result || null;
   },
 
-  async markPendingRunsAsSkipped(
-    failure: {
-      failureCode: string;
-      failureMessage: string;
-      failureDetails?: Record<string, unknown> | null;
-    }
-  ): Promise<DB_SelectCronJobRun[]> {
+  async markPendingRunsAsSkipped(failure: {
+    failureCode: string;
+    failureMessage: string;
+    failureDetails?: Record<string, unknown> | null;
+  }): Promise<DB_SelectCronJobRun[]> {
     const now = new Date();
 
     return await db
@@ -299,13 +297,11 @@ export const QUERIES_CRON_JOB_RUNS = {
       .returning();
   },
 
-  async markRunningRunsAsSkipped(
-    failure: {
-      failureCode: string;
-      failureMessage: string;
-      failureDetails?: Record<string, unknown> | null;
-    }
-  ): Promise<DB_SelectCronJobRun[]> {
+  async markRunningRunsAsSkipped(failure: {
+    failureCode: string;
+    failureMessage: string;
+    failureDetails?: Record<string, unknown> | null;
+  }): Promise<DB_SelectCronJobRun[]> {
     const now = new Date();
 
     return await db

--- a/src/domains/data-provider/typing.ts
+++ b/src/domains/data-provider/typing.ts
@@ -2,22 +2,25 @@ import { DB_InsertMatch } from '@/domains/match/schema';
 import { DB_InsertTeam } from '@/domains/team/schema';
 import { DB_InsertTournamentRound, DB_SelectTournamentRound } from '@/domains/tournament-round/schema';
 import { TournamentQuery } from '@/domains/tournament/queries';
-import { DB_InsertTournament, DB_InsertTournamentStandings, DB_SelectTournament } from '@/domains/tournament/schema';
+import { DB_InsertTournamentStandings, DB_SelectTournament, DB_UpdateTournament } from '@/domains/tournament/schema';
 import { FetchAndStoreAssetPayload } from '@/utils';
 import { Request } from 'express';
 
 export type IApiProvider = {
   tournament: {
-    fetchAndStoreLogo: (data: FetchAndStoreAssetPayload) => Promise<any>;
-    createOnDatabase: (data: any & { logo: string }) => Promise<DB_SelectTournament>;
-    updateOnDatabase: (data: DB_InsertTournament) => Promise<DB_SelectTournament>;
+    fetchAndStoreLogo: (data: FetchAndStoreAssetPayload) => Promise<string>;
+    createOnDatabase: (data: CreateTournamentInput & { logo: string }) => Promise<DB_SelectTournament>;
+    updateOnDatabase: (data: DB_UpdateTournament) => Promise<DB_SelectTournament>;
   };
   rounds: {
     fetchRoundFromProvider: (providerUrl: string) => Promise<API_SOFASCORE_ROUND>;
     fetchShallowListOfRoundsFromProvider: (baseUrl: string) => Promise<API_SOFASCORE_ROUNDS>;
-    mapShallowListOfRounds: (data: API_SOFASCORE_ROUNDS, tournament: NonNullable<TournamentQuery>) => Promise<any[]>;
+    mapShallowListOfRounds: (
+      data: API_SOFASCORE_ROUNDS,
+      tournament: NonNullable<TournamentQuery>
+    ) => Promise<DB_InsertTournamentRound[]>;
     createOnDatabase: (rounds: DB_InsertTournamentRound[]) => Promise<DB_SelectTournamentRound[]>;
-    upsertOnDatabase: (rounds: DB_InsertTournamentRound[]) => Promise<any>;
+    upsertOnDatabase: (rounds: DB_InsertTournamentRound[]) => Promise<DB_SelectTournamentRound[]>;
   };
   matches: {
     mapRoundMatches: (data: {
@@ -25,28 +28,32 @@ export type IApiProvider = {
       roundSlug: string;
       tournamentId: string;
     }) => DB_InsertMatch[];
-    upsertOnDatabase: (matches: DB_InsertMatch[]) => Promise<any>;
-    createOnDatabase: (matches: DB_InsertMatch[]) => Promise<any>;
+    upsertOnDatabase: (matches: DB_InsertMatch[]) => Promise<number>;
+    createOnDatabase: (matches: DB_InsertMatch[]) => Promise<unknown>;
   };
   teams: {
-    fetchAndStoreLogo: (data: FetchAndStoreAssetPayload) => Promise<any>;
-    mapTeamsFromStandings: (standings: any, provider: string) => Promise<DB_InsertTeam[]>;
+    fetchAndStoreLogo: (data: FetchAndStoreAssetPayload) => Promise<string>;
+    mapTeamsFromStandings: (standings: API_SOFASCORE_STANDINGS, provider: string) => Promise<DB_InsertTeam[]>;
     mapTeamsFromRound: (round: API_SOFASCORE_ROUND, provider: string) => Promise<DB_InsertTeam[]>;
     createOnDatabase: (teams: DB_InsertTeam[]) => Promise<DB_InsertTeam[]>;
-    upsertOnDatabase: (teams: DB_InsertTeam[]) => Promise<any>;
+    upsertOnDatabase: (teams: DB_InsertTeam[]) => Promise<DB_InsertTeam[]>;
   };
   standings: {
     fetchStandingsFromProvider: (baseUrl: string) => Promise<API_SOFASCORE_STANDINGS | null>;
-    mapStandings: (data: any, tournamentId: string, tournamentStandingsMode: string) => Promise<any>;
-    createOnDatabase: (standings: any) => Promise<DB_InsertTournamentStandings[]>;
-    upsertOnDatabase: (standings: any) => Promise<any>;
+    mapStandings: (
+      data: API_SOFASCORE_STANDINGS,
+      tournamentId: string,
+      tournamentStandingsMode: string
+    ) => Promise<DB_InsertTournamentStandings[]>;
+    createOnDatabase: (standings: DB_InsertTournamentStandings[]) => Promise<DB_InsertTournamentStandings[]>;
+    upsertOnDatabase: (standings: DB_InsertTournamentStandings[]) => Promise<DB_InsertTournamentStandings[]>;
   };
 };
 
 export interface IDataProviderTournamentRound {
   fetchRoundFromProvider: (providerUrl: string) => Promise<API_SOFASCORE_ROUND>;
   fetchRoundsFromProvider: (providerUrl: string) => Promise<API_SOFASCORE_ROUNDS>;
-  createRoundsOnDatabase: (data: API_SOFASCORE_ROUNDS, tournamentId: string) => Promise<any>;
+  createRoundsOnDatabase: (data: API_SOFASCORE_ROUNDS, tournamentId: string) => Promise<DB_SelectTournamentRound[]>;
 }
 
 export interface IDataProviderMatch {

--- a/src/domains/member/api/index.ts
+++ b/src/domains/member/api/index.ts
@@ -68,7 +68,7 @@ const createMember = async (req: Request, res: Response) => {
         domain: DOMAINS.MEMBER,
         component: 'api',
         operation: 'createMember',
-        errors: errors as any,
+        errors: errors as unknown,
         receivedBody: req.body,
         contentType: req.get('content-type'),
       });


### PR DESCRIPTION
Addressed quality check failures reported by the user.

1.  **Formatting**: Fixed indentation/whitespace in `src/domains/cron/queries/index.ts` using `yarn lint:fix`.
2.  **Unused Variables**: Removed unused `DOMAINS` import in `src/apps/scheduler/startup-recovery.ts`.
3.  **Strict Typing**:
    *   Replaced `any` with specific types in `src/domains/data-provider/typing.ts` for `IApiProvider` interface, using Drizzle schema types (`DB_SelectTournament`, `DB_InsertTournamentRound`, etc.) and API response types (`API_SOFASCORE_ROUND`).
    *   Replaced `any` with `unknown` in `src/domains/auth/api/index.ts` and `src/domains/member/api/index.ts` for `errors` object passed to logger.
4.  **Logger Types**: Modified `src/core/logger/types.ts` to remove the index signature from `LogTags`. This allows passing complex objects (like validation errors) in the logger context (via `LogExtra` intersection), resolving TypeScript errors when using `unknown` instead of `any`.

Verified changes by running `yarn lint` and `yarn compile`, which pass successfully.

---
*PR created automatically by Jules for task [12087718478449996163](https://jules.google.com/task/12087718478449996163) started by @mariobrusarosco*